### PR TITLE
Infra ansible runner register

### DIFF
--- a/infra/ansible/roles/gitlab-ci/tasks/deploy_runner.yml
+++ b/infra/ansible/roles/gitlab-ci/tasks/deploy_runner.yml
@@ -21,32 +21,8 @@
     timeout: 600
     search_regex: 'INFO: Report handlers complete'
 
-- name: Register Gitlab runner
-  docker_container:
-    container_default_behavior: compatibility
-    name: "gitlab-runner-register-{{ '%02d' | format(item) }}"
-    image: gitlab/gitlab-runner:latest
-    state: started
-    auto_remove: true
-    volumes:
-      - "/srv/gitlabrunner-{{ '%02d' | format(item) }}/config:/etc/gitlab-runner"
-      - "/var/run/docker.sock:/var/run/docker.sock"
-    networks:
-      - name: gitlab-net
-        aliases:
-          - "gitlab-runner-register-{{ '%02d' | format(item) }}"
-    purge_networks: true
-    command: >
-        register 
-        --url http://gitlab-ci/ 
-        --non-interactive 
-        --locked=false 
-        --name DockerRunner-{{ '%02d' | format(item) }} 
-        --executor docker 
-        --docker-image alpine:latest 
-        --registration-token {{ gitlab_runner_token }} 
-        --tag-list "docker" 
-        --run-untagged
+- name: Gitlab runner registration
+  include_tasks: register_runner.yml
   loop: "{{ range(0, runners_count)|list }}"
 
 - name: Deploy Gitlab runner

--- a/infra/ansible/roles/gitlab-ci/tasks/deploy_runner.yml
+++ b/infra/ansible/roles/gitlab-ci/tasks/deploy_runner.yml
@@ -33,7 +33,7 @@
     state: started
     restart_policy: always
     volumes:
-      - "/srv/gitlabrunner/config-{{ '%02d' | format(item) }}:/etc/gitlab-runner"
+      - "/srv/gitlabrunner-{{ '%02d' | format(item) }}/config:/etc/gitlab-runner"
       - "/var/run/docker.sock:/var/run/docker.sock"
     networks:
       - name: gitlab-net

--- a/infra/ansible/roles/gitlab-ci/tasks/register_runner.yml
+++ b/infra/ansible/roles/gitlab-ci/tasks/register_runner.yml
@@ -1,0 +1,33 @@
+---
+- name: Check that the runner has not been registered yet
+  stat:
+    path: "/srv/gitlabrunner-{{ '%02d' | format(item) }}/config/config.toml"
+  register: runner_reg
+
+- name: Register Gitlab runner
+  docker_container:
+    container_default_behavior: compatibility
+    name: "gitlab-runner-register-{{ '%02d' | format(item) }}"
+    image: gitlab/gitlab-runner:latest
+    state: started
+    auto_remove: true
+    volumes:
+      - "/srv/gitlabrunner-{{ '%02d' | format(item) }}/config:/etc/gitlab-runner"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      - name: gitlab-net
+        aliases:
+          - "gitlab-runner-register-{{ '%02d' | format(item) }}"
+    purge_networks: true
+    command: >
+        register 
+        --url http://gitlab-ci/ 
+        --non-interactive 
+        --locked=false 
+        --name DockerRunner-{{ '%02d' | format(item) }} 
+        --executor docker 
+        --docker-image alpine:latest 
+        --registration-token {{ gitlab_runner_token }} 
+        --tag-list "docker" 
+        --run-untagged
+  when: not runner_reg.stat.exists


### PR DESCRIPTION
Вынес таски по регистрации в отдельный файл, т.к. задачу по проверке и регистрации нужно выполнять в одном цикле.
Так же, пришлось пофиксить mount volume в деплой таске, т.к. он ссылался не на ту директорию, где лежит конфиг раннера.