### PR TITLE
fix: change yc instance memory

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -11,7 +11,7 @@ resource "yandex_compute_instance" "gitlab_instance" {
 
     resources {
     cores  = 4
-    memory = 10
+    memory = 8
     }
 
     metadata = {


### PR DESCRIPTION
Исправил ошибку с некорректным значением памяти в yc compute instance
Closes #25 